### PR TITLE
Ignore custom Emacs files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /.cache/
 /auto-save-list/
+openaiapikey
+custom.el
+*.elc


### PR DESCRIPTION
## Summary
- extend `.gitignore` to ignore user-specific files and compiled Emacs Lisp

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688098fdab58832badcbb33338606d8d