### PR TITLE
Fix flycheck python hook

### DIFF
--- a/emacs.org
+++ b/emacs.org
@@ -175,8 +175,9 @@
   (use-package flycheck)
 
   (add-hook 'python-mode-hook
-	    (lambda ())
-	    (setq flycheck-python-pylint-executable (concat conda-env-current-path "Scripts/pylint")))
+            (lambda ()
+              (setq flycheck-python-pylint-executable
+                    (concat conda-env-current-path "Scripts/pylint"))))
 
   (global-flycheck-mode)
 #+end_src


### PR DESCRIPTION
## Summary
- correct `add-hook` usage for flycheck's pylint in `python-mode`

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68809aab9568832b8a86df51aac12ceb