### PR TITLE
Fix heading spelling

### DIFF
--- a/emacs.org
+++ b/emacs.org
@@ -1,7 +1,7 @@
 #+title: EMACS INITIALIZATION
 #+startup: overview
 
-* INITIALIZATION AND INTERPORABILITY
+* INITIALIZATION AND INTEROPERABILITY
 ** Very basic setup
 #+begin_src emacs-lisp :results none
   ;; Create another .el file for auto-customizations


### PR DESCRIPTION
## Summary
- correct spelling of first org heading in `emacs.org`
- search repository for any remaining `INTERPORABILITY`

## Testing
- `grep -n "INTERPORABILITY" -n -r --exclude-dir=.git`

------
https://chatgpt.com/codex/tasks/task_e_68809a9f9dc0832b988b9c62fd76895f