### PR TITLE
Update GPTel API key loading

### DIFF
--- a/emacs.org
+++ b/emacs.org
@@ -249,7 +249,7 @@
 
   (with-temp-buffer
     (insert-file-contents "openaiapikey")
-    (setq gptel-api-key (buffer-string)))
+    (setq gptel-api-key (string-trim (buffer-string))))
 
   (setq gptel-default-mode 'text-mode)
 


### PR DESCRIPTION
## Summary
- trim whitespace when loading `openaiapikey` in `emacs.org`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68809ab36398832b948c5e304de9cb93